### PR TITLE
feat: add GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## 📝 Description
+<!-- Describe the purpose of this PR, what changes were made, and why -->
+
+## 📸 Screenshots (if applicable)
+<!-- Add screenshots or GIFs to demonstrate the changes -->
+
+## 🔗 Related Issues
+<!-- Link to related issues using `#issue_number` -->
+
+## 💡 Additional Notes
+<!-- Add any additional information or context -->
+
+## 🔧 Changes Made
+- [ ] ✨ Feature implementation
+- [ ] 🐛 Bug fix
+- [ ] 🔨 Refactoring
+- [ ] 📚 Documentation update
+
+## ✅ Checklist
+- [ ] 📝 Code follows project guidelines
+- [ ] 🚫 No `console.log` statements
+- [ ] 📖 Commit messages are descriptive
+- [ ] 🧪 Tests are added/updated (if necessary)
+- [ ] 🔗 PR linked to an issue (if applicable)


### PR DESCRIPTION
feat: add GitHub PR template  

- Create a pull request template to standardize PR descriptions  
- Include sections for description, changes, screenshots, and testing steps  
- Improve collaboration and maintainability of the repository  
